### PR TITLE
Unification of the /pitches Endpoint and Access Correction

### DIFF
--- a/app/Http/Controllers/EstablishmentController.php
+++ b/app/Http/Controllers/EstablishmentController.php
@@ -8,19 +8,5 @@ use App\Models\Pitch;
 
 class EstablishmentController extends Controller
 {
-    public function pitches(Request $request)
-    {
-        $user = Auth::user();
-        $pitches = Pitch::where('establishment_id', $user->id)
-            ->get()
-            ->map(function ($pitch) {
-                return [
-                    'id' => $pitch->id,
-                    'name' => $pitch->name,
-                    'location' => $pitch->location,
-                ];
-            });
-
-        return response()->json($pitches);
-    }
+    
 }

--- a/app/Http/Controllers/PitchController.php
+++ b/app/Http/Controllers/PitchController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Pitch;
+
+class PitchController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = Auth::user();
+
+        if ($user->role === 'player') {
+            // Para jugadores: devolver todos los pitches disponibles
+            $pitches = Pitch::all()->map(function ($pitch) {
+                return [
+                    'id' => $pitch->id,
+                    'name' => $pitch->name,
+                    'location' => $pitch->location,
+                ];
+            });
+        } elseif ($user->role === 'establishment') {
+            // Para establecimientos: devolver solo los pitches que gestionan
+            $pitches = Pitch::where('establishment_id', $user->id)
+                ->get()
+                ->map(function ($pitch) {
+                    return [
+                        'id' => $pitch->id,
+                        'name' => $pitch->name,
+                        'location' => $pitch->location,
+                    ];
+                });
+        } else {
+            // Si el rol no es player ni establishment, denegar acceso
+            return response()->json(['message' => 'Acceso denegado'], 403);
+        }
+
+        return response()->json($pitches);
+    }
+}

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -41,17 +41,4 @@ class PlayerController extends Controller
 
         return response()->json($fixtures);
     }
-
-    public function pitches(Request $request)
-    {
-        $pitches = Pitch::all()->map(function ($pitch) {
-            return [
-                'id' => $pitch->id,
-                'name' => $pitch->name,
-                'location' => $pitch->location,
-            ];
-        });
-
-        return response()->json($pitches);
-    }
 }

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -15,14 +15,14 @@ class CheckRole
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
-    public function handle(Request $request, Closure $next, $role)
+    public function handle(Request $request, Closure $next, ...$roles)
     {
         if (!Auth::check()) {
             return response()->json(['message' => 'No autenticado'], 401);
         }
 
         $user = Auth::user();
-        if ($user->role !== $role) {
+        if (!in_array($user->role, $roles)) {
             return response()->json(['message' => 'Acceso denegado'], 403);
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PlayerController;
 use App\Http\Controllers\EstablishmentController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\PitchController;
 
 /*
 |--------------------------------------------------------------------------
@@ -32,8 +33,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/user', [AuthController::class, 'getUser']);
     Route::get('/profile', [PlayerController::class, 'profile'])->middleware('role:player');
     Route::get('/fixtures', [PlayerController::class, 'fixtures'])->middleware('role:player');
-    Route::get('/player/pitches', [PlayerController::class, 'pitches'])->middleware('role:player');
-    Route::get('/establishment/pitches', [EstablishmentController::class, 'pitches'])->middleware('role:establishment');
+    Route::get('/pitches', [PitchController::class, 'index'])->middleware('role:player,establishment');
     Route::get('/users', [AdminController::class, 'users'])->middleware('role:admin');
 });
 


### PR DESCRIPTION
Este PR unifica el endpoint /pitches en PitchController y corrige problemas de acceso para los roles player y establishment.

Cambios Realizados
 -Unificado el endpoint /pitches en PitchController para manejar lógica según el rol.
 -Eliminados métodos redundantes pitches de PlayerController y EstablishmentController.
 -Corregido acceso denegado para usuarios player y establishment.
Pruebas Realizadas
 -Verificado que /pitches devuelve datos correctos según el rol (player y establishment).
 -Confirmado que el acceso denegado ya no ocurre para los roles autorizados.