### PR TITLE
Add player reservation functionality

### DIFF
--- a/app/Http/Controllers/PitchController.php
+++ b/app/Http/Controllers/PitchController.php
@@ -12,30 +12,26 @@ class PitchController extends Controller
     {
         $user = Auth::user();
 
-        if ($user->role === 'player') {
-            // Para jugadores: devolver todos los pitches disponibles
-            $pitches = Pitch::all()->map(function ($pitch) {
-                return [
-                    'id' => $pitch->id,
-                    'name' => $pitch->name,
-                    'location' => $pitch->location,
-                ];
-            });
-        } elseif ($user->role === 'establishment') {
-            // Para establecimientos: devolver solo los pitches que gestionan
-            $pitches = Pitch::where('establishment_id', $user->id)
-                ->get()
-                ->map(function ($pitch) {
-                    return [
-                        'id' => $pitch->id,
-                        'name' => $pitch->name,
-                        'location' => $pitch->location,
-                    ];
-                });
-        } else {
-            // Si el rol no es player ni establishment, denegar acceso
+        $query = Pitch::query();
+
+        // Filtrar según el rol del usuario
+        if ($user->role === 'establishment') {
+            $query->where('establishment_id', $user->id);
+        } elseif ($user->role !== 'player' && $user->role !== 'establishment') {
             return response()->json(['message' => 'Acceso denegado'], 403);
         }
+
+        $pitches = $query->with('establishment')->get()->map(function ($pitch) {
+            return [
+                'id' => $pitch->id,
+                'name' => $pitch->name,
+                'location' => $pitch->location,
+                'establishment' => [
+                    'id' => $pitch->establishment->id,
+                    'name' => $pitch->establishment->name,
+                ],
+            ];
+        });
 
         return response()->json($pitches);
     }

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Pitch;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Reservation;
@@ -40,5 +41,56 @@ class PlayerController extends Controller
             });
 
         return response()->json($reservations);
+    }
+
+    public function createReservation(Request $request)
+    {
+        $user = Auth::user();
+
+        $validated = $request->validate([
+            'pitch_id' => 'required|exists:pitches,id',
+            'start_at' => 'required|date|after:now',
+            'duration' => 'required|integer|min:30|max:120',
+        ]);
+
+        // Verificar si el horario está disponible
+        $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
+            ->where('start_at', '<=', $validated['start_at'])
+            ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$validated['start_at']])
+            ->whereNull('cancellation_date')
+            ->exists();
+
+        if ($existingReservation) {
+            return response()->json(['error' => 'El horario seleccionado ya está reservado.'], 400);
+        }
+
+        $pitch = Pitch::find($validated['pitch_id']);
+        $price = $pitch->price ?? 30.00;
+
+        $reservation = Reservation::create([
+            'player_id' => $user->id,
+            'pitch_id' => $validated['pitch_id'],
+            'start_at' => $validated['start_at'],
+            'duration' => $validated['duration'],
+            'price' => $price,
+            'status' => 'pending',
+            'payment_status' => 'pending',
+            'payment_method' => null,
+        ]);
+
+        return response()->json([
+            'message' => 'Reserva creada con éxito.',
+            'reservation' => [
+                'id' => $reservation->id,
+                'start_at' => $reservation->start_at,
+                'duration' => $reservation->duration,
+                'price' => $reservation->price,
+                'pitch' => [
+                    'id' => $pitch->id,
+                    'name' => $pitch->name,
+                    'location' => $pitch->location,
+                ],
+            ]
+        ], 201);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PlayerController;
-use App\Http\Controllers\EstablishmentController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\PitchController;
 
@@ -31,11 +30,24 @@ Route::post('/reset-password', [AuthController::class, 'resetPassword']);
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/user', [AuthController::class, 'getUser']);
-    Route::get('/profile', [PlayerController::class, 'profile'])->middleware('role:player');
-    Route::get('/reservations', [PlayerController::class, 'reservations'])->middleware('role:player');
-    Route::post('/pitches', [PlayerController::class, 'createReservation'])->middleware('role:player');
-    Route::get('/pitches', [PitchController::class, 'index'])->middleware('role:player,establishment');
-    Route::get('/users', [AdminController::class, 'users'])->middleware('role:admin');
+
+    // Rutas para jugadores
+    Route::prefix('player')->middleware('role:player')->group(function () {
+        Route::get('/profile', [PlayerController::class, 'profile']);
+        Route::get('/reservations', [PlayerController::class, 'reservations']);
+        Route::post('/reservations', [PlayerController::class, 'createReservation']);
+        Route::get('/pitches', [PitchController::class, 'index']);
+    });
+
+    // Rutas para establecimientos
+    Route::prefix('establishment')->middleware('role:establishment')->group(function () {
+        Route::get('/pitches', [PitchController::class, 'index']);
+    });
+
+    // Rutas para administradores
+    Route::prefix('admin')->middleware('role:admin')->group(function () {
+        Route::get('/users', [AdminController::class, 'users']);
+    });
 });
 
 Route::get('/reset-password/{token}', [AuthController::class, 'validateResetToken'])->name('password.reset');

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/user', [AuthController::class, 'getUser']);
     Route::get('/profile', [PlayerController::class, 'profile'])->middleware('role:player');
     Route::get('/reservations', [PlayerController::class, 'reservations'])->middleware('role:player');
+    Route::post('/pitches', [PlayerController::class, 'createReservation'])->middleware('role:player');
     Route::get('/pitches', [PitchController::class, 'index'])->middleware('role:player,establishment');
     Route::get('/users', [AdminController::class, 'users'])->middleware('role:admin');
 });


### PR DESCRIPTION
Esta PR añade la funcionalidad para que los jugadores puedan crear reservas en la aplicación. También incluye mejoras en la estructura de rutas y controladores.

Cambios principales:

Refactorización de PitchController::index para incluir la relación con el establecimiento en la respuesta.
Nuevo método createReservation en PlayerController para permitir a los jugadores crear reservas, con validaciones y verificación de disponibilidad.
Nueva ruta POST /reservations para crear reservas, restringida a jugadores.
Reorganización de las rutas en api.php, agrupándolas por rol (player, establishment, admin) para mayor claridad.