### PR TITLE
Create ReservationController and Delegate Reservation Actions

### DIFF
--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -2,13 +2,25 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Pitch;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use App\Models\Reservation;
 
 class PlayerController extends Controller
 {
+    protected $reservationController;
+    protected $pitchController;
+
+    public function __construct(
+        ReservationController $reservationController,
+        PitchController $pitchController
+    ) {
+        $this->reservationController = $reservationController;
+        $this->pitchController = $pitchController;
+    }
+
+    /**
+     * Muestra el perfil del jugador.
+     */
     public function profile(Request $request)
     {
         $user = Auth::user();
@@ -20,77 +32,27 @@ class PlayerController extends Controller
         ]);
     }
 
+    /**
+     * Lista las reservas del jugador
+     */
     public function reservations(Request $request)
     {
-        $reservations = Reservation::where('player_id', auth()->id())
-            ->with('pitch')
-            ->get()
-            ->map(function ($reservation) {
-                return [
-                    'id' => $reservation->id,
-                    'start_at' => $reservation->start_at,
-                    'duration' => $reservation->duration,
-                    'cancelled_at' => $reservation->cancelled_at,
-                    'is_cancelled' => $reservation->cancelled_at !== null,
-                    'pitch' => [
-                        'id' => $reservation->pitch->id,
-                        'name' => $reservation->pitch->name,
-                        'location' => $reservation->pitch->location,
-                    ],
-                ];
-            });
-
-        return response()->json($reservations);
+        return $this->reservationController->index($request);
     }
 
+    /**
+     * Crea una nueva reserva
+     */
     public function createReservation(Request $request)
     {
-        $user = Auth::user();
+        return $this->reservationController->store($request);
+    }
 
-        $validated = $request->validate([
-            'pitch_id' => 'required|exists:pitches,id',
-            'start_at' => 'required|date|after:now',
-            'duration' => 'required|integer|min:30|max:120',
-        ]);
-
-        // Verificar si el horario está disponible
-        $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
-            ->where('start_at', '<=', $validated['start_at'])
-            ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$validated['start_at']])
-            ->whereNull('cancellation_date')
-            ->exists();
-
-        if ($existingReservation) {
-            return response()->json(['error' => 'El horario seleccionado ya está reservado.'], 400);
-        }
-
-        $pitch = Pitch::find($validated['pitch_id']);
-        $price = $pitch->price ?? 30.00;
-
-        $reservation = Reservation::create([
-            'player_id' => $user->id,
-            'pitch_id' => $validated['pitch_id'],
-            'start_at' => $validated['start_at'],
-            'duration' => $validated['duration'],
-            'price' => $price,
-            'status' => 'pending',
-            'payment_status' => 'pending',
-            'payment_method' => null,
-        ]);
-
-        return response()->json([
-            'message' => 'Reserva creada con éxito.',
-            'reservation' => [
-                'id' => $reservation->id,
-                'start_at' => $reservation->start_at,
-                'duration' => $reservation->duration,
-                'price' => $reservation->price,
-                'pitch' => [
-                    'id' => $pitch->id,
-                    'name' => $pitch->name,
-                    'location' => $pitch->location,
-                ],
-            ]
-        ], 201);
+    /**
+     * Lista los campos disponibles
+     */
+    public function getPitches(Request $request)
+    {
+        return $this->pitchController->index($request);
     }
 }

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Pitch;
+use App\Models\Reservation;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+
+class ReservationController extends Controller
+{
+
+    /**
+     * Lista las reservas del jugador
+     */
+    public function index(Request $request)
+    {
+        $reservations = Reservation::where('player_id', auth()->id())
+            ->with('pitch')
+            ->get()
+            ->map(function ($reservation) {
+                return [
+                    'id' => $reservation->id,
+                    'start_at' => $reservation->start_at,
+                    'duration' => $reservation->duration,
+                    'cancelled_at' => $reservation->cancellation_date,
+                    'is_cancelled' => $reservation->cancellation_date !== null,
+                    'pitch' => [
+                        'id' => $reservation->pitch->id,
+                        'name' => $reservation->pitch->name,
+                        'location' => $reservation->pitch->location,
+                    ],
+                ];
+            });
+
+        return response()->json($reservations);
+    }
+
+    /**
+     * Crea una nueva reserva para el jugador
+     */
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+
+        try {
+            $validated = $request->validate([
+                'pitch_id' => 'required|exists:pitches,id',
+                'start_at' => 'required|date|after:now',
+                'duration' => 'required|integer|min:30|max:120',
+            ]);
+
+            // Convertir start_at a un formato estándar (Y-m-d H:i:s)
+            $startAt = Carbon::parse($validated['start_at'])->format('Y-m-d H:i:s');
+            $validated['start_at'] = $startAt;
+
+            // Verificar si el horario está disponible
+            $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
+                ->where('start_at', '<=', $validated['start_at'])
+                ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$validated['start_at']])
+                ->whereNull('cancellation_date')
+                ->first();
+
+            if ($existingReservation) {
+                $conflictStart = Carbon::parse($existingReservation->start_at)->format('d/m/Y H:i');
+                $conflictEnd = Carbon::parse($existingReservation->start_at)
+                    ->addMinutes($existingReservation->duration)
+                    ->format('d/m/Y H:i');
+
+                Log::warning('Intento de reserva fallido: horario ya reservado', [
+                    'user_id' => $user->id,
+                    'pitch_id' => $validated['pitch_id'],
+                    'start_at' => $validated['start_at'],
+                    'duration' => $validated['duration'],
+                    'conflict_start' => $conflictStart,
+                    'conflict_end' => $conflictEnd,
+                    'ip' => $request->ip(),
+                ]);
+
+                return response()->json([
+                    'message' => 'El horario seleccionado ya está reservado.',
+                    'details' => "El campo está ocupado desde $conflictStart hasta $conflictEnd. Por favor, elige otro horario o campo.",
+                ], 400);
+            }
+
+            $pitch = Pitch::findOrFail($validated['pitch_id']);
+            $price = $pitch->price ?? 30.00;
+
+            $reservation = Reservation::create([
+                'player_id' => $user->id,
+                'pitch_id' => $validated['pitch_id'],
+                'start_at' => $validated['start_at'],
+                'duration' => $validated['duration'],
+                'price' => $price,
+                'status' => 'pending',
+                'payment_status' => 'pending',
+                'payment_method' => null,
+            ]);
+
+            Log::info('Reserva creada con éxito', [
+                'reservation_id' => $reservation->id,
+                'user_id' => $user->id,
+                'pitch_id' => $validated['pitch_id'],
+                'start_at' => $validated['start_at'],
+                'duration' => $validated['duration'],
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json([
+                'message' => 'Reserva creada con éxito.',
+                'reservation' => [
+                    'id' => $reservation->id,
+                    'start_at' => $reservation->start_at,
+                    'duration' => $reservation->duration,
+                    'price' => $reservation->price,
+                    'pitch' => [
+                        'id' => $pitch->id,
+                        'name' => $pitch->name,
+                        'location' => $pitch->location,
+                    ],
+                ],
+            ], 201);
+        } catch (ValidationException $e) {
+            Log::warning('Error de validación al crear reserva', [
+                'user_id' => $user->id ?? null,
+                'errors' => $e->errors(),
+                'ip' => $request->ip(),
+            ]);
+            return response()->json([
+                'message' => 'Datos de reserva inválidos.',
+                'details' => $e->errors(),
+            ], 400);
+        } catch (\Exception $e) {
+            Log::error('Error inesperado al crear reserva', [
+                'user_id' => $user->id ?? null,
+                'message' => $e->getMessage(),
+                'ip' => $request->ip(),
+            ]);
+            return response()->json([
+                'message' => 'Error inesperado al crear la reserva.',
+                'details' => 'Por favor, intenta de nuevo más tarde.',
+            ], 500);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,7 +36,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/profile', [PlayerController::class, 'profile']);
         Route::get('/reservations', [PlayerController::class, 'reservations']);
         Route::post('/reservations', [PlayerController::class, 'createReservation']);
-        Route::get('/pitches', [PitchController::class, 'index']);
+        Route::get('/pitches', [PlayerController::class, 'getPitches']);
     });
 
     // Rutas para establecimientos


### PR DESCRIPTION
Esta PR introduce el nuevo `ReservationController` y delega las acciones relacionadas con reservas desde `PlayerController`, mejorando la modularidad y el manejo de errores.

**Cambios principales:**
- Creado `ReservationController` con los métodos `index` (listar reservas) y `store` (crear reserva).
- Delegadas las acciones de reservas desde `PlayerController` a `ReservationController`.
- Mejorada la lógica de creación de reservas con `Carbon` para un manejo flexible de fechas y mensajes de error detallados con horarios conflictivos.
- Actualizado `PlayerController` para delegar la lista de campos a `PitchController` mediante el método `getPitches`.
- Ajustadas las rutas en `api.php` para reflejar la nueva estructura de delegación.

**Pruebas realizadas:**
- Verificado que las reservas se crean correctamente con horarios no solapados.
- Confirmado que los mensajes de error muestran los horarios conflictivos (por ejemplo, "El campo está ocupado desde 05/09/2025 22:30 hasta 05/09/2025 23:30").
- Comprobado que las rutas delegadas funcionan correctamente para jugadores.