### PR TITLE
Standardize API Responses with ApiResponser Trait

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Traits\ApiResponser;
 use Illuminate\Http\Request;
 use App\Models\User;
 
 class AdminController extends Controller
 {
+    use ApiResponser;
+
     public function users(Request $request)
     {
         $users = User::all()->map(function ($user) {
@@ -18,6 +21,6 @@ class AdminController extends Controller
             ];
         });
 
-        return response()->json($users);
+        return $this->successResponse(['users' => $users], 'Usuarios obtenidos con éxito');
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Traits\ApiResponser;
 use App\Models\User;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\Request;
@@ -11,10 +12,11 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
 {
+    use ApiResponser;
+
     public function register(Request $request)
     {
         try {
@@ -40,32 +42,12 @@ class AuthController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json([
-                'message' => 'Usuario registrado con éxito',
+            return $this->successResponse([
                 'user' => $user,
                 'token' => $token,
-            ], 201);
-        } catch (ValidationException $e) {
-            Log::warning('Error de validación en registro', [
-                'email' => $request->email,
-                'errors' => $e->errors(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error de validación',
-                'errors' => $e->errors(),
-            ], 422);
+            ], 'Usuario registrado con éxito', 201);
         } catch (\Exception $e) {
-            Log::error('Error inesperado en registro', [
-                'email' => $request->email,
-                'error' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error al registrar el usuario',
-            ], 500);
+            return $this->handleException($e, $request, 'registro');
         }
     }
 
@@ -83,9 +65,7 @@ class AuthController extends Controller
                     'ip' => $request->ip(),
                 ]);
 
-                return response()->json([
-                    'message' => 'Credenciales inválidas',
-                ], 401);
+                return $this->errorResponse('Credenciales inválidas', 401);
             }
 
             $user = Auth::user();
@@ -98,32 +78,12 @@ class AuthController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json([
-                'message' => 'Inicio de sesión exitoso',
+            return $this->successResponse([
                 'user' => $user,
                 'token' => $token,
-            ], 200);
-        } catch (ValidationException $e) {
-            Log::warning('Error de validación en login', [
-                'email' => $request->email,
-                'errors' => $e->errors(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error de validación',
-                'errors' => $e->errors(),
-            ], 422);
+            ], 'Inicio de sesión exitoso');
         } catch (\Exception $e) {
-            Log::error('Error inesperado en login', [
-                'email' => $request->email,
-                'error' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error al iniciar sesión',
-            ], 500);
+            return $this->handleException($e, $request, 'login');
         }
     }
 
@@ -138,19 +98,9 @@ class AuthController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json([
-                'message' => 'Sesión cerrada con éxito',
-            ], 200);
+            return $this->successResponse([], 'Sesión cerrada con éxito');
         } catch (\Exception $e) {
-            Log::error('Error al cerrar sesión', [
-                'email' => $request->user()->email,
-                'error' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error al cerrar sesión',
-            ], 500);
+            return $this->handleException($e, $request, 'logout');
         }
     }
 
@@ -164,19 +114,11 @@ class AuthController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json([
-                'message' => 'Usuario obtenido con éxito',
+            return $this->successResponse([
                 'user' => $user,
-            ], 200);
+            ], 'Usuario obtenido con éxito');
         } catch (\Exception $e) {
-            Log::error('Error al obtener usuario', [
-                'error' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error al obtener el usuario',
-            ], 500);
+            return $this->handleException($e, $request, 'obtención de usuario');
         }
     }
 
@@ -195,9 +137,7 @@ class AuthController extends Controller
                     'ip' => $request->ip(),
                 ]);
 
-                return response()->json([
-                    'message' => 'Enlace de recuperación enviado al correo',
-                ], 200);
+                return $this->successResponse([], 'Enlace de recuperación enviado al correo');
             }
 
             Log::warning('Error al enviar enlace de recuperación', [
@@ -205,30 +145,9 @@ class AuthController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json([
-                'message' => 'No se pudo enviar el enlace de recuperación',
-            ], 400);
-        } catch (ValidationException $e) {
-            Log::warning('Error de validación en recuperación de contraseña', [
-                'email' => $request->email,
-                'errors' => $e->errors(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error de validación',
-                'errors' => $e->errors(),
-            ], 422);
+            return $this->errorResponse('No se pudo enviar el enlace de recuperación', 400);
         } catch (\Exception $e) {
-            Log::error('Error inesperado en recuperación de contraseña', [
-                'email' => $request->email,
-                'error' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error al procesar la solicitud',
-            ], 500);
+            return $this->handleException($e, $request, 'recuperación de contraseña');
         }
     }
 
@@ -258,9 +177,7 @@ class AuthController extends Controller
                     'email' => $validated['email'],
                     'ip' => $request->ip(),
                 ]);
-                return response()->json([
-                    'message' => 'Contraseña restablecida con éxito',
-                ], 200);
+                return $this->successResponse([], 'Contraseña restablecida con éxito');
             }
 
             Log::warning('Error al restablecer la contraseña', [
@@ -268,30 +185,9 @@ class AuthController extends Controller
                 'status' => $status,
                 'ip' => $request->ip(),
             ]);
-            return response()->json([
-                'message' => 'No se pudo restablecer la contraseña',
-            ], 400);
-        } catch (ValidationException $e) {
-            Log::warning('Error de validación en restablecimiento de contraseña', [
-                'email' => $request->email,
-                'errors' => $e->errors(),
-                'ip' => $request->ip(),
-            ]);
-            return response()->json([
-                'message' => 'Error de validación',
-                'errors' => $e->errors(),
-            ], 422);
+            return $this->errorResponse('No se pudo restablecer la contraseña', 400);
         } catch (\Exception $e) {
-            Log::error('Error inesperado en restablecimiento de contraseña', [
-                'email' => $request->email,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-                'ip' => $request->ip(),
-            ]);
-            return response()->json([
-                'message' => 'Error al procesar la solicitud',
-                'error' => $e->getMessage(),
-            ], 500);
+            return $this->handleException($e, $request, 'restablecimiento de contraseña');
         }
     }
 
@@ -307,9 +203,7 @@ class AuthController extends Controller
                     'token' => $token,
                     'ip' => $request->ip(),
                 ]);
-                return response()->json([
-                    'message' => 'Token inválido o expirado',
-                ], 400);
+                return $this->errorResponse('Token inválido o expirado', 400);
             }
 
             $createdAt = \Carbon\Carbon::parse($resetToken->created_at);
@@ -320,9 +214,7 @@ class AuthController extends Controller
                     'email' => $resetToken->email,
                     'ip' => $request->ip(),
                 ]);
-                return response()->json([
-                    'message' => 'Token expirado',
-                ], 400);
+                return $this->errorResponse('Token expirado', 400);
             }
 
             Log::info('Token de restablecimiento válido', [
@@ -330,19 +222,12 @@ class AuthController extends Controller
                 'email' => $resetToken->email,
                 'ip' => $request->ip(),
             ]);
-            return response()->json([
+            return $this->successResponse([
                 'email' => $resetToken->email,
                 'token' => $token,
-            ], 200);
+            ], 'Token válido');
         } catch (\Exception $e) {
-            Log::error('Error al validar el token de restablecimiento', [
-                'token' => $token,
-                'error' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-            return response()->json([
-                'message' => 'Error al procesar la solicitud',
-            ], 500);
+            return $this->handleException($e, $request, 'validación de token de restablecimiento');
         }
     }
 }

--- a/app/Http/Controllers/PitchController.php
+++ b/app/Http/Controllers/PitchController.php
@@ -2,37 +2,43 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Traits\ApiResponser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Pitch;
 
 class PitchController extends Controller
 {
+    use ApiResponser;
+
     public function index(Request $request)
     {
-        $user = Auth::user();
+        try {
+            $user = Auth::user();
+            $query = Pitch::query();
 
-        $query = Pitch::query();
+            // Filtrar según el rol del usuario
+            if ($user->role === 'establishment') {
+                $query->where('establishment_id', $user->id);
+            } elseif ($user->role !== 'player' && $user->role !== 'establishment') {
+                return $this->errorResponse('Acceso denegado', 403);
+            }
 
-        // Filtrar según el rol del usuario
-        if ($user->role === 'establishment') {
-            $query->where('establishment_id', $user->id);
-        } elseif ($user->role !== 'player' && $user->role !== 'establishment') {
-            return response()->json(['message' => 'Acceso denegado'], 403);
+            $pitches = $query->with('establishment')->get()->map(function ($pitch) {
+                return [
+                    'id' => $pitch->id,
+                    'name' => $pitch->name,
+                    'location' => $pitch->location,
+                    'establishment' => [
+                        'id' => $pitch->establishment->id,
+                        'name' => $pitch->establishment->name,
+                    ],
+                ];
+            });
+
+            return $this->successResponse(['pitches' => $pitches], 'Campos obtenidos con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'obtención de campos');
         }
-
-        $pitches = $query->with('establishment')->get()->map(function ($pitch) {
-            return [
-                'id' => $pitch->id,
-                'name' => $pitch->name,
-                'location' => $pitch->location,
-                'establishment' => [
-                    'id' => $pitch->establishment->id,
-                    'name' => $pitch->establishment->name,
-                ],
-            ];
-        });
-
-        return response()->json($pitches);
     }
 }

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Traits\ApiResponser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class PlayerController extends Controller
 {
+    use ApiResponser;
+
     protected $reservationController;
     protected $pitchController;
 
@@ -24,12 +27,12 @@ class PlayerController extends Controller
     public function profile(Request $request)
     {
         $user = Auth::user();
-        return response()->json([
+        return $this->successResponse([
             'id' => $user->id,
             'name' => $user->name,
             'email' => $user->email,
             'role' => $user->role,
-        ]);
+        ], 'Perfil obtenido con éxito');
     }
 
     /**

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -2,41 +2,46 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Traits\ApiResponser;
 use App\Models\Pitch;
 use App\Models\Reservation;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Validation\ValidationException;
 
 class ReservationController extends Controller
 {
+    use ApiResponser;
 
     /**
      * Lista las reservas del jugador
      */
     public function index(Request $request)
     {
-        $reservations = Reservation::where('player_id', auth()->id())
-            ->with('pitch')
-            ->get()
-            ->map(function ($reservation) {
-                return [
-                    'id' => $reservation->id,
-                    'start_at' => $reservation->start_at,
-                    'duration' => $reservation->duration,
-                    'cancelled_at' => $reservation->cancellation_date,
-                    'is_cancelled' => $reservation->cancellation_date !== null,
-                    'pitch' => [
-                        'id' => $reservation->pitch->id,
-                        'name' => $reservation->pitch->name,
-                        'location' => $reservation->pitch->location,
-                    ],
-                ];
-            });
+        try {
+            $reservations = Reservation::where('player_id', auth()->id())
+                ->with('pitch')
+                ->get()
+                ->map(function ($reservation) {
+                    return [
+                        'id' => $reservation->id,
+                        'start_at' => $reservation->start_at,
+                        'duration' => $reservation->duration,
+                        'cancelled_at' => $reservation->cancellation_date,
+                        'is_cancelled' => $reservation->cancellation_date !== null,
+                        'pitch' => [
+                            'id' => $reservation->pitch->id,
+                            'name' => $reservation->pitch->name,
+                            'location' => $reservation->pitch->location,
+                        ],
+                    ];
+                });
 
-        return response()->json($reservations);
+            return $this->successResponse(['reservations' => $reservations], 'Reservas obtenidas con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'obtención de reservas');
+        }
     }
 
     /**
@@ -80,10 +85,11 @@ class ReservationController extends Controller
                     'ip' => $request->ip(),
                 ]);
 
-                return response()->json([
-                    'message' => 'El horario seleccionado ya está reservado.',
-                    'details' => "El campo está ocupado desde $conflictStart hasta $conflictEnd. Por favor, elige otro horario o campo.",
-                ], 400);
+                return $this->errorResponse(
+                    'El horario seleccionado ya está reservado.',
+                    400,
+                    ['details' => "El campo está ocupado desde $conflictStart hasta $conflictEnd. Por favor, elige otro horario o campo."]
+                );
             }
 
             $pitch = Pitch::findOrFail($validated['pitch_id']);
@@ -109,8 +115,7 @@ class ReservationController extends Controller
                 'ip' => $request->ip(),
             ]);
 
-            return response()->json([
-                'message' => 'Reserva creada con éxito.',
+            return $this->successResponse([
                 'reservation' => [
                     'id' => $reservation->id,
                     'start_at' => $reservation->start_at,
@@ -122,135 +127,75 @@ class ReservationController extends Controller
                         'location' => $pitch->location,
                     ],
                 ],
-            ], 201);
-        } catch (ValidationException $e) {
-            Log::warning('Error de validación al crear reserva', [
-                'user_id' => $user->id ?? null,
-                'errors' => $e->errors(),
-                'ip' => $request->ip(),
-            ]);
-            return response()->json([
-                'message' => 'Datos de reserva inválidos.',
-                'details' => $e->errors(),
-            ], 400);
+            ], 'Reserva creada con éxito', 201);
         } catch (\Exception $e) {
-            Log::error('Error inesperado al crear reserva', [
-                'user_id' => $user->id ?? null,
-                'message' => $e->getMessage(),
-                'ip' => $request->ip(),
-            ]);
-            return response()->json([
-                'message' => 'Error inesperado al crear la reserva.',
-                'details' => 'Por favor, intenta de nuevo más tarde.',
-            ], 500);
+            return $this->handleException($e, $request, 'creación de reserva');
         }
     }
 
     public function checkAvailability(Request $request)
     {
-        $user = Auth::user();
+        try {
+            $validated = $request->validate([
+                'pitch_id' => 'required|exists:pitches,id',
+                'start_at' => 'required|date|after:now',
+                'duration' => 'required|integer|min:30|max:120',
+            ]);
 
-        $validated = $request->validate([
-            'pitch_id' => 'required|exists:pitches,id',
-            'start_at' => 'required|date|after:now',
-            'duration' => 'required|integer|min:30|max:120',
-        ]);
+            $startAt = Carbon::parse($validated['start_at'])->format('Y-m-d H:i:s');
+            $endAt = Carbon::parse($startAt)->addMinutes($validated['duration']);
 
-        $startAt = Carbon::parse($validated['start_at'])->format('Y-m-d H:i:s');
-        $endAt = Carbon::parse($startAt)->addMinutes($validated['duration']);
-
-        $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
-            ->where(function ($query) use ($startAt, $endAt) {
-                $query->where('start_at', '<', $endAt)
-                      ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$startAt]);
-            })
-            ->whereNull('cancellation_date')
-            ->first();
-
-        if ($existingReservation) {
-            $conflictStart = Carbon::parse($existingReservation->start_at)->format('d/m/Y H:i');
-            $conflictEnd = Carbon::parse($existingReservation->start_at)
-                ->addMinutes($existingReservation->duration)
-                ->format('d/m/Y H:i');
-            return response()->json([
-                'available' => false,
-                'message' => "El campo está ocupado desde $conflictStart hasta $conflictEnd."
-            ], 200);
-        }
-
-        return response()->json(['available' => true], 200);
-    }
-
-    public function getAvailableTimes(Request $request)
-    {
-        $validated = $request->validate([
-            'pitch_id' => 'required|exists:pitches,id',
-            'date' => 'required|date',
-        ]);
-
-        $date = Carbon::parse($validated['date'])->startOfDay();
-        $availableTimes = [];
-        $allTimes = [];
-        for ($hour = 8; $hour < 22; $hour++) {
-            $allTimes[] = sprintf("%02d:00", $hour);
-            $allTimes[] = sprintf("%02d:30", $hour);
-        }
-
-        $now = Carbon::now();
-        if ($date->isSameDay($now)) {
-            $currentHour = $now->hour;
-            $currentMinute = $now->minute;
-            $nextHalfHour = ceil($currentMinute / 30) * 30;
-            $startHour = $currentHour + ($nextHalfHour === 60 ? 1 : ($nextHalfHour === 0 ? 0 : 1));
-            $allTimes = array_filter($allTimes, function ($time) use ($startHour) {
-                $hour = (int)explode(':', $time)[0];
-                return $hour >= $startHour;
-            });
-        }
-
-        foreach ($allTimes as $time) {
-            $startAt = $date->copy()->setTimeFromTimeString($time);
-            $endAt = $startAt->copy()->addMinutes(30); // intervalos de 30 minutos para verificar
             $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
                 ->where(function ($query) use ($startAt, $endAt) {
                     $query->where('start_at', '<', $endAt)
-                          ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$startAt]);
+                        ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$startAt]);
                 })
                 ->whereNull('cancellation_date')
                 ->first();
 
-            if (!$existingReservation) {
-                $availableTimes[] = $time;
+            if ($existingReservation) {
+                $conflictStart = Carbon::parse($existingReservation->start_at)->format('d/m/Y H:i');
+                $conflictEnd = Carbon::parse($existingReservation->start_at)
+                    ->addMinutes($existingReservation->duration)
+                    ->format('d/m/Y H:i');
+                return $this->successResponse([
+                    'available' => false,
+                    'message' => "El campo está ocupado desde $conflictStart hasta $conflictEnd."
+                ], 'Horario no disponible');
             }
-        }
 
-        return response()->json(['availableTimes' => $availableTimes], 200);
+            return $this->successResponse(['available' => true], 'Horario disponible');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'verificación de disponibilidad');
+        }
     }
 
-    public function getAvailableDates(Request $request)
+    public function getAvailableTimes(Request $request)
     {
-        $validated = $request->validate([
-            'pitch_id' => 'required|exists:pitches,id',
-            'start_date' => 'required|date',
-            'end_date' => 'required|date|after_or_equal:start_date',
-        ]);
+        try {
+            $validated = $request->validate([
+                'pitch_id' => 'required|exists:pitches,id',
+                'date' => 'required|date',
+            ]);
 
-        $startDate = Carbon::parse($validated['start_date'])->startOfDay();
-        $endDate = Carbon::parse($validated['end_date'])->endOfDay();
-        $now = Carbon::now();
-        $maxEndDate = $now->copy()->addDays(15)->endOfDay();
-
-        if ($endDate > $maxEndDate) {
-            $endDate = $maxEndDate;
-        }
-
-        $dates = [];
-        for ($date = $startDate; $date <= $endDate; $date->addDay()) {
+            $date = Carbon::parse($validated['date'])->startOfDay();
             $availableTimes = [];
             $allTimes = [];
             for ($hour = 8; $hour < 22; $hour++) {
                 $allTimes[] = sprintf("%02d:00", $hour);
                 $allTimes[] = sprintf("%02d:30", $hour);
+            }
+
+            $now = Carbon::now();
+            if ($date->isSameDay($now)) {
+                $currentHour = $now->hour;
+                $currentMinute = $now->minute;
+                $nextHalfHour = ceil($currentMinute / 30) * 30;
+                $startHour = $currentHour + ($nextHalfHour === 60 ? 1 : ($nextHalfHour === 0 ? 0 : 1));
+                $allTimes = array_filter($allTimes, function ($time) use ($startHour) {
+                    $hour = (int)explode(':', $time)[0];
+                    return $hour >= $startHour;
+                });
             }
 
             foreach ($allTimes as $time) {
@@ -259,7 +204,7 @@ class ReservationController extends Controller
                 $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
                     ->where(function ($query) use ($startAt, $endAt) {
                         $query->where('start_at', '<', $endAt)
-                              ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$startAt]);
+                            ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$startAt]);
                     })
                     ->whereNull('cancellation_date')
                     ->first();
@@ -269,12 +214,64 @@ class ReservationController extends Controller
                 }
             }
 
-            $dates[] = [
-                'date' => $date->format('Y-m-d'),
-                'available' => !empty($availableTimes)
-            ];
+            return $this->successResponse(['availableTimes' => $availableTimes], 'Horarios disponibles obtenidos con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'obtención de horarios disponibles');
         }
+    }
 
-        return response()->json($dates, 200);
+    public function getAvailableDates(Request $request)
+    {
+        try {
+            $validated = $request->validate([
+                'pitch_id' => 'required|exists:pitches,id',
+                'start_date' => 'required|date',
+                'end_date' => 'required|date|after_or_equal:start_date',
+            ]);
+
+            $startDate = Carbon::parse($validated['start_date'])->startOfDay();
+            $endDate = Carbon::parse($validated['end_date'])->endOfDay();
+            $now = Carbon::now();
+            $maxEndDate = $now->copy()->addDays(15)->endOfDay();
+
+            if ($endDate > $maxEndDate) {
+                $endDate = $maxEndDate;
+            }
+
+            $dates = [];
+            for ($date = $startDate; $date <= $endDate; $date->addDay()) {
+                $availableTimes = [];
+                $allTimes = [];
+                for ($hour = 8; $hour < 22; $hour++) {
+                    $allTimes[] = sprintf("%02d:00", $hour);
+                    $allTimes[] = sprintf("%02d:30", $hour);
+                }
+
+                foreach ($allTimes as $time) {
+                    $startAt = $date->copy()->setTimeFromTimeString($time);
+                    $endAt = $startAt->copy()->addMinutes(30); // intervalos de 30 minutos para verificar
+                    $existingReservation = Reservation::where('pitch_id', $validated['pitch_id'])
+                        ->where(function ($query) use ($startAt, $endAt) {
+                            $query->where('start_at', '<', $endAt)
+                                ->whereRaw('DATE_ADD(start_at, INTERVAL duration MINUTE) > ?', [$startAt]);
+                        })
+                        ->whereNull('cancellation_date')
+                        ->first();
+
+                    if (!$existingReservation) {
+                        $availableTimes[] = $time;
+                    }
+                }
+
+                $dates[] = [
+                    'date' => $date->format('Y-m-d'),
+                    'available' => !empty($availableTimes)
+                ];
+            }
+
+            return $this->successResponse(['dates' => $dates], 'Fechas disponibles obtenidas con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'obtención de fechas disponibles');
+        }
     }
 }

--- a/app/Http/Traits/ApiResponser.php
+++ b/app/Http/Traits/ApiResponser.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Traits;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Trait para estandarizar respuestas JSON y manejo de errores en los controladores.
+ * @author Álvaro Coo Igeño
+ */
+trait ApiResponser
+{
+    /**
+     * Devuelve una respuesta JSON exitosa.
+     *
+     * @param array $data Datos adicionales a incluir en la respuesta.
+     * @param string $message Mensaje de éxito.
+     * @param int $code Código HTTP.
+     * @return JsonResponse
+     */
+    protected function successResponse(array $data = [], string $message = 'Operación exitosa', int $code = 200): JsonResponse
+    {
+        return response()->json(array_merge(['message' => $message], $data), $code);
+    }
+
+    /**
+     * Devuelve una respuesta JSON de error.
+     *
+     * @param string $message Mensaje de error.
+     * @param int $code Código HTTP.
+     * @param array $errors Errores adicionales (por ejemplo, de validación).
+     * @return JsonResponse
+     */
+    protected function errorResponse(string $message = 'Error en la operación', int $code = 500, array $errors = []): JsonResponse
+    {
+        return response()->json(['message' => $message, 'errors' => $errors], $code);
+    }
+
+    /**
+     * Maneja excepciones y registra errores en el log.
+     *
+     * @param \Exception $e Excepción capturada.
+     * @param Request $request Request actual.
+     * @param string $context Contexto de la operación (por ejemplo, 'registro').
+     * @return JsonResponse
+     */
+    protected function handleException(\Exception $e, Request $request, string $context): JsonResponse
+    {
+        if ($e instanceof ValidationException) {
+            Log::warning("Error de validación en $context", [
+                'errors' => $e->errors(),
+                'ip' => $request->ip(),
+            ]);
+            return $this->errorResponse('Error de validación', 422, $e->errors());
+        }
+
+        if ($e instanceof ModelNotFoundException) {
+            Log::warning("Recurso no encontrado en $context", [
+                'error' => $e->getMessage(),
+                'ip' => $request->ip(),
+            ]);
+            return $this->errorResponse('Recurso no encontrado', 404);
+        }
+
+        if ($e instanceof AuthenticationException || $e instanceof AuthorizationException) {
+            Log::warning("Acceso denegado en $context", [
+                'error' => $e->getMessage(),
+                'ip' => $request->ip(),
+            ]);
+            return $this->errorResponse('Acceso denegado', 403);
+        }
+
+        Log::error("Error inesperado en $context", [
+            'error' => $e->getMessage(),
+            'ip' => $request->ip(),
+            'stack_trace' => $e->getTraceAsString(),
+        ]);
+        return $this->errorResponse('Error inesperado', 500);
+    }
+}


### PR DESCRIPTION
Esta PR introduce el trait ApiResponser para estandarizar las respuestas de la API en todo el backend, asegurando respuestas coherentes tanto en casos de éxito como de error. También centraliza el manejo de excepciones y mejora el registro de logs.

Añadir el trait ApiResponser para respuestas estandarizadas en la API

Integrar el trait ApiResponser en AuthController

Integrar el trait ApiResponser en AdminController y PlayerController

Integrar el trait ApiResponser en PitchController y ReservationController