### PR TITLE
Add Stripe Payment Integration to Backend

### DIFF
--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -8,7 +8,10 @@ use App\Models\Reservation;
 use App\Services\ReservationService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Stripe\Stripe;
+use Stripe\PaymentIntent;
 
 class ReservationController extends Controller
 {
@@ -61,6 +64,7 @@ class ReservationController extends Controller
                 'pitch_id' => 'required|exists:pitches,id',
                 'start_at' => 'required|date|after:now',
                 'duration' => 'required|integer|min:60|max:120',
+                'stripe_payment_intent_id' => 'required|string', // Nuevo campo
             ]);
 
             $startAt = Carbon::parse($validated['start_at']);
@@ -84,16 +88,27 @@ class ReservationController extends Controller
             $pitch = Pitch::findOrFail($validated['pitch_id']);
             $price = $pitch->price ?? 30.00;
 
-            $reservation = Reservation::create([
-                'player_id' => auth()->id(),
-                'pitch_id' => $validated['pitch_id'],
-                'start_at' => $startAt->format('Y-m-d H:i:s'),
-                'duration' => $validated['duration'],
-                'price' => $price,
-                'status' => 'pending',
-                'payment_status' => 'pending',
-                'payment_method' => null,
-            ]);
+            // Verificar el Payment Intent
+            Stripe::setApiKey(config('services.stripe.secret'));
+            $paymentIntent = PaymentIntent::retrieve($validated['stripe_payment_intent_id']);
+
+            if ($paymentIntent->status !== 'succeeded') {
+                return $this->errorResponse('El pago no se ha completado', 400);
+            }
+
+            $reservation = DB::transaction(function () use ($validated, $startAt, $pitch, $price) {
+                return Reservation::create([
+                    'player_id' => auth()->id(),
+                    'pitch_id' => $validated['pitch_id'],
+                    'start_at' => $startAt->format('Y-m-d H:i:s'),
+                    'duration' => $validated['duration'],
+                    'price' => $price,
+                    'status' => 'confirmed',
+                    'payment_status' => 'completed',
+                    'payment_method' => 'card',
+                    'stripe_payment_intent_id' => $validated['stripe_payment_intent_id'],
+                ]);
+            });
 
             Log::info('Reserva creada con éxito', [
                 'reservation_id' => $reservation->id,
@@ -101,6 +116,7 @@ class ReservationController extends Controller
                 'pitch_id' => $validated['pitch_id'],
                 'start_at' => $startAt->toDateTimeString(),
                 'duration' => $validated['duration'],
+                'stripe_payment_intent_id' => $validated['stripe_payment_intent_id'],
                 'ip' => $request->ip(),
             ]);
 
@@ -110,6 +126,7 @@ class ReservationController extends Controller
                     'start_at' => $reservation->start_at,
                     'duration' => $reservation->duration,
                     'price' => $reservation->price,
+                    'stripe_payment_intent_id' => $reservation->stripe_payment_intent_id,
                     'pitch' => [
                         'id' => $pitch->id,
                         'name' => $pitch->name,
@@ -195,6 +212,52 @@ class ReservationController extends Controller
             return $this->successResponse(['dates' => $dates], 'Fechas disponibles obtenidas con éxito');
         } catch (\Exception $e) {
             return $this->handleException($e, $request, 'obtención de fechas disponibles');
+        }
+    }
+
+    public function createPaymentIntent(Request $request)
+    {
+        Log::info('Solicitud recibida', $request->all());
+
+        try {
+            $validated = $request->validate([
+                'pitch_id' => 'required|exists:pitches,id',
+                'start_at' => 'required|date|after:now',
+                'duration' => 'required|integer|min:60|max:120',
+            ]);
+
+            $pitch = Pitch::findOrFail($validated['pitch_id']);
+            $price = $pitch->price ?? 30.00;
+
+            // Configurar Stripe
+            Stripe::setApiKey(config('services.stripe.secret'));
+
+            // Crear Payment Intent
+            $paymentIntent = PaymentIntent::create([
+                'amount' => $price * 100, // Stripe usa centavos
+                'currency' => 'eur',
+                'payment_method_types' => ['card'],
+                'metadata' => [
+                    'pitch_id' => $validated['pitch_id'],
+                    'player_id' => auth()->id(),
+                    'start_at' => $validated['start_at'],
+                    'duration' => $validated['duration'],
+                ],
+            ]);
+
+            Log::info('Payment Intent creado', [
+                'payment_intent_id' => $paymentIntent->id,
+                'user_id' => auth()->id(),
+                'pitch_id' => $validated['pitch_id'],
+                'amount' => $price,
+            ]);
+
+            return $this->successResponse([
+                'client_secret' => $paymentIntent->client_secret,
+            ], 'Payment Intent creado con éxito');
+        } catch (\Exception $e) {
+            Log::error('Error al crear Payment Intent', ['error' => $e->getMessage()]);
+            return $this->errorResponse('Error al crear el intento de pago', 500);
         }
     }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -18,6 +18,7 @@ class Reservation extends Model
         'price',
         'payment_status',
         'payment_method',
+        'stripe_payment_intent_id',
         'cancellation_reason',
         'cancellation_date'
     ];

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",
-        "laravel/tinker": "^2.7"
+        "laravel/tinker": "^2.7",
+        "stripe/stripe-php": "^17.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe33f98a750b8c5a51b30c78bd3fab21",
+    "content-hash": "55702a4d615e944321f34b097d683d8d",
     "packages": [
         {
             "name": "brick/math",
@@ -3155,6 +3155,65 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v17.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "cfe8244f7e5f910b7fdb5c2cf77428c0acbb9f7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/cfe8244f7e5f910b7fdb5c2cf77428c0acbb9f7c",
+                "reference": "cfe8244f7e5f910b7fdb5c2cf77428c0acbb9f7c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.72.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v17.3.0"
+            },
+            "time": "2025-05-28T18:59:29+00:00"
         },
         {
             "name": "symfony/console",

--- a/config/services.php
+++ b/config/services.php
@@ -31,4 +31,9 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'stripe' => [
+        'key' => env('STRIPE_KEY'),
+        'secret' => env('STRIPE_SECRET'),
+    ],
+
 ];

--- a/database/migrations/2025_04_30_142854_create_reservations_table.php
+++ b/database/migrations/2025_04_30_142854_create_reservations_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
             $table->enum('status', ['pending', 'confirmed', 'cancelled'])->default('pending');
             $table->enum('payment_status', ['pending', 'completed', 'failed'])->nullable();
             $table->string('payment_method')->nullable();
+            $table->string('stripe_payment_intent_id')->nullable()->unique();
             $table->text('cancellation_reason')->nullable();
             $table->dateTime('cancellation_date')->nullable();
             $table->timestamps();

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('/reservations/check', [ReservationController::class, 'checkAvailability']);
         Route::get('/reservations/available-times', [ReservationController::class, 'getAvailableTimes']);
         Route::get('/reservations/available-dates', [ReservationController::class, 'getAvailableDates']);
+        Route::post('/reservations/create-payment-intent', [ReservationController::class, 'createPaymentIntent']);
     });
 
     // Rutas para establecimientos


### PR DESCRIPTION
Este pull request integra la funcionalidad de pagos con Stripe, permitiendo la creación de Payment Intents y su vinculación con las reservas.

Cambios:
Añadida la dependencia del SDK de Stripe para PHP.

Añadida la columna stripe_payment_intent_id a la tabla de reservas.

Actualizado el modelo Reservation con el campo stripe_payment_intent_id.

Añadida la configuración de Stripe en services.php.

Implementada la creación de Payment Intents de Stripe junto con la creación de reservas.

Objetivo:
Permitir el procesamiento seguro de pagos para las reservas.

Garantizar la consistencia de los datos mediante transacciones en la base de datos.

Almacenar los identificadores de los Payment Intents para su seguimiento.

Pruebas:
Verificado que la creación de Payment Intents funciona con datos válidos del campo de juego.

Confirmado que las reservas solo se crean tras la verificación exitosa del pago.

Probado el manejo de errores para pagos inválidos o horarios no disponibles.