### PR TITLE
Add Pitch Management Functionality for Establishments

### DIFF
--- a/app/Http/Controllers/EstablishmentController.php
+++ b/app/Http/Controllers/EstablishmentController.php
@@ -2,11 +2,59 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Traits\ApiResponser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use App\Models\Pitch;
+use App\Http\Controllers\PitchController;
 
 class EstablishmentController extends Controller
 {
-    
+    use ApiResponser;
+
+    protected $pitchController;
+
+    public function __construct(PitchController $pitchController)
+    {
+        $this->pitchController = $pitchController;
+    }
+
+    /**
+     * Lista todos los pitches del establecimiento (incluye soft deleted).
+     */
+    public function getPitches(Request $request)
+    {
+        return $this->pitchController->index($request);
+    }
+
+    /**
+     * Muestra un pitch específico del establecimiento.
+     */
+    public function showPitch(Request $request, $id)
+    {
+        return $this->pitchController->show($request, $id);
+    }
+
+    /**
+     * Crea un nuevo pitch para el establecimiento.
+     */
+    public function createPitch(Request $request)
+    {
+        return $this->pitchController->store($request);
+    }
+
+    /**
+     * Actualiza un pitch del establecimiento.
+     */
+    public function updatePitch(Request $request, $id)
+    {
+        return $this->pitchController->update($request, $id);
+    }
+
+    /**
+     * Marca un pitch como eliminado (soft delete).
+     */
+    public function deletePitch(Request $request, $id)
+    {
+        return $this->pitchController->destroy($request, $id);
+    }
 }

--- a/app/Http/Controllers/PitchController.php
+++ b/app/Http/Controllers/PitchController.php
@@ -6,6 +6,8 @@ use App\Http\Traits\ApiResponser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Pitch;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class PitchController extends Controller
 {
@@ -14,21 +16,40 @@ class PitchController extends Controller
     public function index(Request $request)
     {
         try {
-            $user = Auth::user();
-            $query = Pitch::query();
+            $pitches = Pitch::where('establishment_id', auth()->id())
+                ->withTrashed() // Incluye campos eliminados (soft deleted)
+                ->get()
+                ->map(function ($pitch) {
+                    return [
+                        'id' => $pitch->id,
+                        'name' => $pitch->name,
+                        'location' => $pitch->location,
+                        'price' => $pitch->price,
+                        'description' => $pitch->description,
+                        'establishment' => [
+                            'id' => $pitch->establishment->id,
+                            'name' => $pitch->establishment->name,
+                        ],
+                        'deleted_at' => $pitch->deleted_at,
+                    ];
+                });
 
-            // Filtrar según el rol del usuario
-            if ($user->role === 'establishment') {
-                $query->where('establishment_id', $user->id);
-            } elseif ($user->role !== 'player' && $user->role !== 'establishment') {
-                return $this->errorResponse('Acceso denegado', 403);
-            }
+            return $this->successResponse(['pitches' => $pitches], 'Campos obtenidos con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'obtención de campos');
+        }
+    }
 
-            $pitches = $query->with('establishment')->get()->map(function ($pitch) {
+    public function availablePitches(Request $request)
+    {
+        try {
+            $pitches = Pitch::whereNull('deleted_at')->with('establishment')->get()->map(function ($pitch) {
                 return [
                     'id' => $pitch->id,
                     'name' => $pitch->name,
                     'location' => $pitch->location,
+                    'price' => $pitch->price,
+                    'description' => $pitch->description,
                     'establishment' => [
                         'id' => $pitch->establishment->id,
                         'name' => $pitch->establishment->name,
@@ -36,9 +57,85 @@ class PitchController extends Controller
                 ];
             });
 
-            return $this->successResponse(['pitches' => $pitches], 'Campos obtenidos con éxito');
+            return $this->successResponse(['pitches' => $pitches], 'Campos disponibles obtenidos con éxito');
         } catch (\Exception $e) {
-            return $this->handleException($e, $request, 'obtención de campos');
+            return $this->handleException($e, $request, 'obtención de campos disponibles');
+        }
+    }
+
+    public function show(Request $request, $id)
+    {
+        try {
+            $pitch = Pitch::where('establishment_id', auth()->id())->findOrFail($id);
+            return $this->successResponse(['pitch' => $pitch], 'Campo obtenido con éxito');
+        } catch (\Exception $e) {
+            Log::error('Error en obtención de campo', ['error' => $e->getMessage(), 'user_id' => auth()->id()]);
+            return $this->handleException($e, $request, 'obtención de campo');
+        }
+    }
+
+    public function store(Request $request)
+    {
+        try {
+            $validated = $request->validate([
+                'name' => 'required|string|max:255',
+                'location' => 'required|string|max:255',
+                'price' => 'required|numeric|min:0',
+                'description' => 'nullable|string|max:1000',
+            ]);
+
+            $pitch = DB::transaction(function () use ($validated) {
+                return Pitch::create([
+                    'establishment_id' => auth()->id(),
+                    'name' => $validated['name'],
+                    'location' => $validated['location'],
+                    'price' => $validated['price'],
+                    'description' => $validated['description'],
+                ]);
+            });
+
+            Log::info('Campo creado con éxito', ['pitch_id' => $pitch->id, 'user_id' => auth()->id()]);
+
+            return $this->successResponse(['pitch' => $pitch], 'Campo creado con éxito', 201);
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'creación de campo');
+        }
+    }
+
+    public function update(Request $request, $id)
+    {
+        try {
+            $validated = $request->validate([
+                'name' => 'required|string|max:255',
+                'location' => 'required|string|max:255',
+                'price' => 'required|numeric|min:0',
+                'description' => 'nullable|string',
+            ]);
+
+            $pitch = Pitch::where('establishment_id', auth()->id())->findOrFail($id);
+
+            $pitch->update($validated);
+
+            Log::info('Campo actualizado con éxito', ['pitch_id' => $pitch->id, 'user_id' => auth()->id()]);
+
+            return $this->successResponse(['pitch' => $pitch], 'Campo actualizado con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'actualización de campo');
+        }
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        try {
+            $pitch = Pitch::where('establishment_id', auth()->id())->findOrFail($id);
+
+            $pitch->delete();
+
+            Log::info('Campo marcado como eliminado con éxito', ['pitch_id' => $pitch->id, 'user_id' => auth()->id()]);
+
+            return $this->successResponse([], 'Campo eliminado con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'eliminación de campo');
         }
     }
 }

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -58,6 +58,6 @@ class PlayerController extends Controller
      */
     public function getPitches(Request $request)
     {
-        return $this->pitchController->index($request);
+        return $this->pitchController->availablePitches($request);
     }
 }

--- a/app/Models/Pitch.php
+++ b/app/Models/Pitch.php
@@ -4,12 +4,21 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Pitch extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
-    protected $fillable = ['name', 'location', 'establishment_id'];
+    protected $fillable = [
+        'establishment_id',
+        'name',
+        'location',
+        'price',
+        'description',
+    ];
+
+    protected $dates = ['deleted_at'];
 
     public function establishment()
     {

--- a/database/migrations/2025_04_30_142759_create_pitches_table.php
+++ b/database/migrations/2025_04_30_142759_create_pitches_table.php
@@ -15,9 +15,12 @@ return new class extends Migration
     {
         Schema::create('pitches', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('establishment_id')->constrained('users')->onDelete('cascade');
             $table->string('name');
             $table->string('location');
-            $table->foreignId('establishment_id')->constrained('users')->onDelete('cascade');
+            $table->decimal('price', 8, 2);
+            $table->text('description')->nullable();
+            $table->softDeletes();
             $table->timestamps();
         });
     }

--- a/database/seeders/PitchSeeder.php
+++ b/database/seeders/PitchSeeder.php
@@ -16,6 +16,8 @@ class PitchSeeder extends Seeder
             Pitch::create([
                 'name' => 'Main Pitch',
                 'location' => '123 Sports Ave',
+                'price' => 15,
+                'description' => 'The main pitch for all major events.',
                 'establishment_id' => $establishment->id,
             ]);
         }

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PlayerController;
 use App\Http\Controllers\AdminController;
-use App\Http\Controllers\PitchController;
+use App\Http\Controllers\EstablishmentController;
 use App\Http\Controllers\ReservationController;
 
 /*
@@ -46,7 +46,11 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // Rutas para establecimientos
     Route::prefix('establishment')->middleware('role:establishment')->group(function () {
-        Route::get('/pitches', [PitchController::class, 'index']);
+        Route::get('/pitches', [EstablishmentController::class, 'getPitches']);
+        Route::get('/pitches/{id}', [EstablishmentController::class, 'showPitch']);
+        Route::post('/pitches', [EstablishmentController::class, 'createPitch']);
+        Route::put('/pitches/{id}', [EstablishmentController::class, 'updatePitch']);
+        Route::delete('/pitches/{id}', [EstablishmentController::class, 'deletePitch']);
     });
 
     // Rutas para administradores


### PR DESCRIPTION
Este pull request añade funcionalidad para que los establecimientos puedan gestionar sus campos, incluyendo la visualización, creación, edición y eliminación lógica (soft delete) de los mismos.

Cambios:
Añadidas rutas API para la gestión de campos por parte del establecimiento.

Creada la tabla pitches con soporte para soft deletes.

Añadido el modelo Pitch con soft delete y relaciones.

Añadido PitchSeeder con datos iniciales.

Implementado PitchController para la gestión de campos.

Actualizado EstablishmentController para manejar los campos.

Actualizado PlayerController para obtener solo los campos disponibles.

Objetivo:
Permitir a los establecimientos gestionar completamente sus campos.

Asegurar que los campos puedan eliminarse de forma lógica para conservar el historial.

Garantizar que los jugadores solo vean campos activos.

Pruebas:
Verificado que los establecimientos pueden listar, crear, editar y eliminar campos.

Confirmado que los campos eliminados lógicamente se marcan como inactivos, pero siguen siendo visibles para los establecimientos.

Probado que los jugadores solo ven los campos activos.