### PR TITLE
Add Reservation Management Functionality for Establishments

### DIFF
--- a/app/Http/Controllers/EstablishmentController.php
+++ b/app/Http/Controllers/EstablishmentController.php
@@ -6,6 +6,10 @@ use App\Http\Traits\ApiResponser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\PitchController;
+use App\Models\Reservation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
 
 class EstablishmentController extends Controller
 {
@@ -19,7 +23,7 @@ class EstablishmentController extends Controller
     }
 
     /**
-     * Lista todos los pitches del establecimiento (incluye soft deleted).
+     * Lista todos los pitches del establecimiento.
      */
     public function getPitches(Request $request)
     {
@@ -56,5 +60,88 @@ class EstablishmentController extends Controller
     public function deletePitch(Request $request, $id)
     {
         return $this->pitchController->destroy($request, $id);
+    }
+
+    /**
+     * Lista todas las reservas de los campos del establecimiento.
+     */
+    public function getReservations(Request $request)
+    {
+        try {
+            $reservations = Reservation::whereHas('pitch', function ($query) {
+                $query->where('establishment_id', Auth::id());
+            })
+                ->with(['pitch', 'player'])
+                ->get()
+                ->map(function ($reservation) {
+                    return [
+                        'id' => $reservation->id,
+                        'start_at' => $reservation->start_at,
+                        'duration' => $reservation->duration,
+                        'price' => $reservation->price,
+                        'status' => $reservation->status,
+                        'cancellation_reason' => $reservation->cancellation_reason,
+                        'cancellation_date' => $reservation->cancellation_date,
+                        'player' => [
+                            'id' => $reservation->player->id,
+                            'name' => $reservation->player->name,
+                            'email' => $reservation->player->email,
+                        ],
+                        'pitch' => [
+                            'id' => $reservation->pitch->id,
+                            'name' => $reservation->pitch->name,
+                            'location' => $reservation->pitch->location,
+                        ],
+                    ];
+                });
+
+            Log::info('Reservas obtenidas por establecimiento', [
+                'user_id' => Auth::id(),
+                'ip' => $request->ip(),
+            ]);
+
+            return $this->successResponse(['reservations' => $reservations], 'Reservas obtenidas con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'obtención de reservas');
+        }
+    }
+
+    /**
+     * Cancela una reserva específica del establecimiento.
+     */
+    public function cancelReservation(Request $request, $id)
+    {
+        try {
+            $validated = $request->validate([
+                'cancellation_reason' => 'required|string|max:1000',
+            ]);
+
+            $reservation = Reservation::whereHas('pitch', function ($query) {
+                $query->where('establishment_id', Auth::id());
+            })->findOrFail($id);
+
+            if ($reservation->status === 'cancelled') {
+                return $this->errorResponse('La reserva ya está cancelada', 400);
+            }
+
+            DB::transaction(function () use ($reservation, $validated) {
+                $reservation->update([
+                    'status' => 'cancelled',
+                    'cancellation_reason' => $validated['cancellation_reason'],
+                    'cancellation_date' => Carbon::now(),
+                ]);
+            });
+
+            Log::info('Reserva cancelada por establecimiento', [
+                'reservation_id' => $reservation->id,
+                'user_id' => Auth::id(),
+                'reason' => $validated['cancellation_reason'],
+                'ip' => $request->ip(),
+            ]);
+
+            return $this->successResponse([], 'Reserva cancelada con éxito');
+        } catch (\Exception $e) {
+            return $this->handleException($e, $request, 'cancelación de reserva');
+        }
     }
 }

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -38,8 +38,10 @@ class ReservationController extends Controller
                         'id' => $reservation->id,
                         'start_at' => $reservation->start_at,
                         'duration' => $reservation->duration,
-                        'cancelled_at' => $reservation->cancellation_date,
-                        'is_cancelled' => $reservation->cancellation_date !== null,
+                        'price' => $reservation->price,
+                        'status' => $reservation->status,
+                        'cancellation_reason' => $reservation->cancellation_reason,
+                        'cancellation_date' => $reservation->cancellation_date,
                         'pitch' => [
                             'id' => $reservation->pitch->id,
                             'name' => $reservation->pitch->name,
@@ -47,6 +49,11 @@ class ReservationController extends Controller
                         ],
                     ];
                 });
+
+            Log::info('Reservas obtenidas por jugador', [
+                'user_id' => auth()->id(),
+                'ip' => $request->ip(),
+            ]);
 
             return $this->successResponse(['reservations' => $reservations], 'Reservas obtenidas con éxito');
         } catch (\Exception $e) {
@@ -64,7 +71,7 @@ class ReservationController extends Controller
                 'pitch_id' => 'required|exists:pitches,id',
                 'start_at' => 'required|date|after:now',
                 'duration' => 'required|integer|min:60|max:120',
-                'stripe_payment_intent_id' => 'required|string', // Nuevo campo
+                'stripe_payment_intent_id' => 'required|string',
             ]);
 
             $startAt = Carbon::parse($validated['start_at']);
@@ -126,6 +133,7 @@ class ReservationController extends Controller
                     'start_at' => $reservation->start_at,
                     'duration' => $reservation->duration,
                     'price' => $reservation->price,
+                    'status' => $reservation->status,
                     'stripe_payment_intent_id' => $reservation->stripe_payment_intent_id,
                     'pitch' => [
                         'id' => $pitch->id,
@@ -215,9 +223,12 @@ class ReservationController extends Controller
         }
     }
 
+    /**
+     * Crea un intento de pago con Stripe para una reserva.
+     */
     public function createPaymentIntent(Request $request)
     {
-        Log::info('Solicitud recibida', $request->all());
+        Log::info('Solicitud de creación de Payment Intent recibida', $request->all());
 
         try {
             $validated = $request->validate([
@@ -245,18 +256,22 @@ class ReservationController extends Controller
                 ],
             ]);
 
-            Log::info('Payment Intent creado', [
+            Log::info('Payment Intent creado con éxito', [
                 'payment_intent_id' => $paymentIntent->id,
                 'user_id' => auth()->id(),
                 'pitch_id' => $validated['pitch_id'],
                 'amount' => $price,
+                'ip' => $request->ip(),
             ]);
 
             return $this->successResponse([
                 'client_secret' => $paymentIntent->client_secret,
             ], 'Payment Intent creado con éxito');
         } catch (\Exception $e) {
-            Log::error('Error al crear Payment Intent', ['error' => $e->getMessage()]);
+            Log::error('Error al crear Payment Intent', [
+                'error' => $e->getMessage(),
+                'ip' => $request->ip(),
+            ]);
             return $this->errorResponse('Error al crear el intento de pago', 500);
         }
     }

--- a/app/Models/Pitch.php
+++ b/app/Models/Pitch.php
@@ -24,4 +24,9 @@ class Pitch extends Model
     {
         return $this->belongsTo(User::class, 'establishment_id');
     }
+
+    public function reservations()
+    {
+        return $this->hasMany(Reservation::class, 'pitch_id');
+    }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Reservation extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'player_id',
@@ -25,7 +26,8 @@ class Reservation extends Model
 
     protected $dates = [
         'start_at',
-        'cancellation_date'
+        'cancellation_date',
+        'deleted_at'
     ];
 
     public function player()

--- a/app/Observers/PitchObserver.php
+++ b/app/Observers/PitchObserver.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Pitch;
+use Carbon\Carbon;
+
+class PitchObserver
+{
+    /**
+     * Handle the Pitch "created" event.
+     *
+     * @param  \App\Models\Pitch  $pitch
+     * @return void
+     */
+    public function created(Pitch $pitch)
+    {
+        //
+    }
+
+    /**
+     * Handle the Pitch "updated" event.
+     *
+     * @param  \App\Models\Pitch  $pitch
+     * @return void
+     */
+    public function updated(Pitch $pitch)
+    {
+        //
+    }
+
+    /**
+     * Handle the Pitch "deleted" event.
+     *
+     * @param  \App\Models\Pitch  $pitch
+     * @return void
+     */
+    public function deleted(Pitch $pitch)
+    {
+        //
+    }
+
+    /**
+     * Maneja el evento "deleting" (soft delete) del modelo Pitch.
+     */
+    public function deleting(Pitch $pitch)
+    {
+        // Marcar todas las reservas asociadas como eliminadas
+        $pitch->reservations()->update([
+            'deleted_at' => Carbon::now(),
+            'status' => 'cancelled',
+            'cancellation_reason' => 'Campo eliminado por el establecimiento',
+            'cancellation_date' => Carbon::now(),
+        ]);
+    }
+
+    /**
+     * Handle the Pitch "restored" event.
+     *
+     * @param  \App\Models\Pitch  $pitch
+     * @return void
+     */
+    public function restored(Pitch $pitch)
+    {
+        //
+    }
+
+    /**
+     * Handle the Pitch "force deleted" event.
+     *
+     * @param  \App\Models\Pitch  $pitch
+     * @return void
+     */
+    public function forceDeleted(Pitch $pitch)
+    {
+        //
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Pitch;
+use App\Observers\PitchObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -39,4 +41,8 @@ class EventServiceProvider extends ServiceProvider
     {
         return false;
     }
+
+    protected $observers = [
+        Pitch::class => [PitchObserver::class],
+    ];
 }

--- a/database/migrations/2025_04_30_142854_create_reservations_table.php
+++ b/database/migrations/2025_04_30_142854_create_reservations_table.php
@@ -26,6 +26,7 @@ return new class extends Migration
             $table->string('stripe_payment_intent_id')->nullable()->unique();
             $table->text('cancellation_reason')->nullable();
             $table->dateTime('cancellation_date')->nullable();
+            $table->softDeletes();
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -51,6 +51,8 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('/pitches', [EstablishmentController::class, 'createPitch']);
         Route::put('/pitches/{id}', [EstablishmentController::class, 'updatePitch']);
         Route::delete('/pitches/{id}', [EstablishmentController::class, 'deletePitch']);
+        Route::get('/reservations', [EstablishmentController::class, 'getReservations']);
+        Route::delete('/reservations/{id}', [EstablishmentController::class, 'cancelReservation']);
     });
 
     // Rutas para administradores


### PR DESCRIPTION
Este pull request añade funcionalidad para que los establecimientos gestionen las reservas de sus campos, incluyendo la visualización y cancelación de reservas.

Cambios:
Añadidas rutas API para la gestión de reservas por parte del establecimiento.

Actualizada la tabla reservations con campos de cancelación y soporte para soft delete.

Actualizado el modelo Reservation con soporte para cancelación y eliminación lógica.

Añadida la relación de reservas en el modelo Pitch.

Añadido PitchObserver para limpiar reservas al eliminar un campo.

Implementados los métodos getReservations y cancelReservation en EstablishmentController.

Objetivo:
Permitir a los establecimientos ver y cancelar reservas de sus propios campos.

Asegurar la coherencia eliminando lógicamente las reservas asociadas cuando se elimina un campo.

Proporcionar un proceso de cancelación seguro.

Pruebas:
Verificado que los establecimientos pueden listar todas las reservas de sus campos.

Confirmado que las cancelaciones requieren un motivo y actualizan el estado de la reserva.

Probado que al eliminar lógicamente un campo también se limpian las reservas asociadas.

Asegurado que el soporte de transacciones funciona correctamente durante la cancelación.