### PR TITLE
Add Refund Functionality on Reservation Cancellation

### DIFF
--- a/app/Http/Controllers/EstablishmentController.php
+++ b/app/Http/Controllers/EstablishmentController.php
@@ -10,6 +10,9 @@ use App\Models\Reservation;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
+use Stripe\Refund;
+use Stripe\Stripe;
+use Stripe\Exception\ApiErrorException;
 
 class EstablishmentController extends Controller
 {
@@ -120,28 +123,50 @@ class EstablishmentController extends Controller
                 $query->where('establishment_id', Auth::id());
             })->findOrFail($id);
 
+            if (!is_null($reservation->deleted_at)) {
+                return $this->errorResponse('La reserva ya está eliminada', 400);
+            }
+
             if ($reservation->status === 'cancelled') {
                 return $this->errorResponse('La reserva ya está cancelada', 400);
             }
 
+            if (is_null($reservation->stripe_payment_intent_id)) {
+                return $this->errorResponse('No hay información de pago para reembolsar', 400);
+            }
+
             DB::transaction(function () use ($reservation, $validated) {
+                Stripe::setApiKey(config('services.stripe.secret'));
+
+                try {
+                    Refund::create([
+                        'payment_intent' => $reservation->stripe_payment_intent_id,
+                        'amount' => (int) ($reservation->price * 100), // Convertir a centavos
+                        'reason' => 'requested_by_customer',
+                    ]);
+                } catch (ApiErrorException $e) {
+                    throw new \Exception('Error al procesar el reembolso: ' . $e->getMessage());
+                }
+
                 $reservation->update([
                     'status' => 'cancelled',
                     'cancellation_reason' => $validated['cancellation_reason'],
                     'cancellation_date' => Carbon::now(),
+                    'payment_status' => 'refunded',
                 ]);
             });
 
-            Log::info('Reserva cancelada por establecimiento', [
+            Log::info('Reserva cancelada y reembolsada por establecimiento', [
                 'reservation_id' => $reservation->id,
                 'user_id' => Auth::id(),
                 'reason' => $validated['cancellation_reason'],
+                'stripe_payment_intent_id' => $reservation->stripe_payment_intent_id,
                 'ip' => $request->ip(),
             ]);
 
-            return $this->successResponse([], 'Reserva cancelada con éxito');
+            return $this->successResponse([], 'Reserva cancelada y reembolsada con éxito');
         } catch (\Exception $e) {
-            return $this->handleException($e, $request, 'cancelación de reserva');
+            return $this->handleException($e, $request, 'cancelación y reembolso de reserva');
         }
     }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -30,6 +30,14 @@ class Reservation extends Model
         'deleted_at'
     ];
 
+    protected $attributes = [
+        'payment_status' => 'pending',
+    ];
+
+    protected $casts = [
+        'payment_status' => 'string',
+    ];
+
     public function player()
     {
         return $this->belongsTo(User::class, 'player_id');

--- a/database/migrations/2025_04_30_142854_create_reservations_table.php
+++ b/database/migrations/2025_04_30_142854_create_reservations_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->integer('duration');
             $table->decimal('price', 8, 2);
             $table->enum('status', ['pending', 'confirmed', 'cancelled'])->default('pending');
-            $table->enum('payment_status', ['pending', 'completed', 'failed'])->nullable();
+            $table->enum('payment_status', ['pending', 'completed', 'failed', 'refunded'])->nullable();
             $table->string('payment_method')->nullable();
             $table->string('stripe_payment_intent_id')->nullable()->unique();
             $table->text('cancellation_reason')->nullable();


### PR DESCRIPTION
Este pull request añade funcionalidad de reembolso cuando un establecimiento cancela una reserva, utilizando el stripe_payment_intent_id para procesar el reembolso a través de Stripe.

Cambios:

Se añade la lógica de reembolso en EstablishmentController@cancelReservation.

Se actualiza el modelo Reservation para incluir el estado de pago reembolsado.

Se actualiza la tabla Reservation para que payment_status pueda tener estado refunded

Objetivo:
Permitir que se realicen reembolsos automáticos a los jugadores cuando los establecimientos cancelen reservas.

Asegurar que el estado del pago se actualice correctamente tras el reembolso.

Mantener la coherencia de los datos mediante transacciones.

Pruebas:
Verificado que las cancelaciones generan un reembolso si existe un stripe_payment_intent_id.

Confirmado que payment_status se actualiza a 'refunded' tras un reembolso exitoso.

Probado el manejo de errores para intents de pago no válidos.

Asegurado que, en caso de fallo al reembolsar, se realiza rollback de la transacción.
