### PR TITLE
Add Refund Logic for Future Reservations on Pitch Deletion

### DIFF
--- a/app/Observers/PitchObserver.php
+++ b/app/Observers/PitchObserver.php
@@ -3,7 +3,13 @@
 namespace App\Observers;
 
 use App\Models\Pitch;
+use App\Models\Reservation;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Stripe\Exception\ApiErrorException;
+use Stripe\Refund;
+use Stripe\Stripe;
 
 class PitchObserver
 {
@@ -45,13 +51,44 @@ class PitchObserver
      */
     public function deleting(Pitch $pitch)
     {
-        // Marcar todas las reservas asociadas como eliminadas
-        $pitch->reservations()->update([
-            'deleted_at' => Carbon::now(),
-            'status' => 'cancelled',
-            'cancellation_reason' => 'Campo eliminado por el establecimiento',
-            'cancellation_date' => Carbon::now(),
-        ]);
+        $now = Carbon::now();
+
+        // Obtener solo las reservas futuras
+        $futureReservations = $pitch->reservations()
+            ->where('start_at', '>', $now)
+            ->whereNotNull('stripe_payment_intent_id')
+            ->get();
+
+        DB::transaction(function () use ($pitch, $futureReservations, $now) {
+            foreach ($futureReservations as $reservation) {
+                try {
+                    Stripe::setApiKey(config('services.stripe.secret'));
+
+                    // Realizar reembolso
+                    Refund::create([
+                        'payment_intent' => $reservation->stripe_payment_intent_id,
+                        'amount' => (int) ($reservation->price * 100), // Convertir a centavos
+                        'reason' => 'requested_by_customer',
+                    ]);
+
+                    // Actualizar reserva
+                    $reservation->update([
+                        'status' => 'cancelled',
+                        'cancellation_reason' => 'Campo eliminado por el establecimiento',
+                        'cancellation_date' => $now,
+                        'payment_status' => 'refunded',
+                    ]);
+                } catch (ApiErrorException $e) {
+                    Log::error('Error al reembolsar reserva al eliminar campo', [
+                        'reservation_id' => $reservation->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+
+            // Marcar el campo como eliminado
+            $pitch->update(['deleted_at' => $now]);
+        });
     }
 
     /**


### PR DESCRIPTION
Este pull request actualiza el PitchObserver para gestionar reembolsos y cancelaciones solo para reservas futuras cuando se elimina un campo, dejando las reservas pasadas sin cambios.

Cambios:
Se actualiza PitchObserver para reembolsar únicamente las reservas futuras al eliminar un campo.

Objetivo:
Asegurar que los reembolsos solo se procesen para reservas que aún no hayan comenzado.

Marcar como canceladas solo las reservas futuras al eliminar un campo.

Preservar la integridad de las reservas pasadas.

Pruebas:
Verificado que al eliminar un campo se reembolsan y cancelan solo las reservas futuras.

Confirmado que las reservas pasadas permanecen sin modificaciones.

Probado el manejo de errores en reembolsos fallidos, sin revertir la eliminación del campo.