### PR TITLE
Add Dynamic Pricing Based on Reservation Duration

### DIFF
--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -93,7 +93,7 @@ class ReservationController extends Controller
             }
 
             $pitch = Pitch::findOrFail($validated['pitch_id']);
-            $price = $pitch->price ?? 30.00;
+            $price = $pitch->price * $validated['duration'] / 60 ?? 30.00;
 
             // Verificar el Payment Intent
             Stripe::setApiKey(config('services.stripe.secret'));
@@ -238,7 +238,7 @@ class ReservationController extends Controller
             ]);
 
             $pitch = Pitch::findOrFail($validated['pitch_id']);
-            $price = $pitch->price ?? 30.00;
+            $price = $pitch->price * $validated['duration'] / 60 ?? 30.00;
 
             // Configurar Stripe
             Stripe::setApiKey(config('services.stripe.secret'));


### PR DESCRIPTION
Este pull request añade la funcionalidad de precio dinámico para calcular el precio de la reserva en función de la duración, multiplicando el precio por hora del campo por el tiempo reservado (en horas).

Cambios:
Se actualiza ReservationController para calcular el precio basado en la duración en los métodos store y createPaymentIntent.

Objetivo:
Permitir que el precio refleje el tiempo real reservado (por ejemplo: 1h, 1.5h, 2h).

Asegurar consistencia entre el PaymentIntent de Stripe y el precio almacenado en la reserva.

Mantener compatibilidad con la lógica existente de pagos y reembolsos.

Pruebas:
Verificado que el precio se escala correctamente según la duración (por ejemplo: 30€/h → 60min = 30€, 90min = 45€).

Confirmado que el PaymentIntent de Stripe refleja el precio calculado.

Probada la creación de reservas con diferentes duraciones (60, 90 y 120 minutos).